### PR TITLE
Split the hub step in two

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ It uses the `hub` by Github program, available [here](https://hub.github.com/).
 
 # How to install it?
 
-- Make sure you've installed [Hub](https://hub.github.com/). **Run `hub browse` once for Hub to remember your credentials**.
+- Make sure you've installed [Hub](https://hub.github.com/).
+- **Run `hub browse` once for Hub to remember your credentials**.
 - Download the git-pretty-pull-request script in this repository and make sure it's available in your $PATH (put it in /usr/local/bin for example).
 - Make sure the script is executable : `chmod +x /usr/local/bin/git-pretty-pull-request`
 - In each of your projects, set the branches on which you want to open pull requests: `git config pretty-pull-request.pull-bases "integration preprod prod"` (or set it globally with the `--global` option)


### PR DESCRIPTION
I installed `hub` and I missed the `hub browse` step.

I think it would be better with one action by line.

Edit: It doesn't fixed my issue.
Since I activated the 2-factor authentification, I had to remove ~/.config/hub and use `hub browse` again.